### PR TITLE
fix: update to Node.js 22

### DIFF
--- a/cdk/BackendStack.ts
+++ b/cdk/BackendStack.ts
@@ -70,7 +70,7 @@ export class BackendStack extends Stack {
 				hash: layer.hash,
 			}).code,
 			compatibleArchitectures: [Lambda.Architecture.ARM_64],
-			compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+			compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 		})
 
 		const jwtLayerVersion = new Lambda.LayerVersion(this, 'jwtLayer', {
@@ -81,7 +81,7 @@ export class BackendStack extends Stack {
 				hash: jwtLayer.hash,
 			}).code,
 			compatibleArchitectures: [Lambda.Architecture.ARM_64],
-			compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+			compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 		})
 
 		const publicDevices = new PublicDevices(this)
@@ -116,7 +116,7 @@ export class BackendStack extends Stack {
 					hash: cdkLayer.hash,
 				}).code,
 				compatibleArchitectures: [Lambda.Architecture.ARM_64],
-				compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+				compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 			})
 			const domain = new CustomDomain(this, {
 				api,

--- a/cdk/resources/api/HealthCheck.ts
+++ b/cdk/resources/api/HealthCheck.ts
@@ -23,7 +23,7 @@ export class ApiHealthCheck extends Construct {
 		this.fn = new Lambda.Function(this, 'fn', {
 			handler: lambdaSources.apiHealthCheck.handler,
 			architecture: Lambda.Architecture.ARM_64,
-			runtime: Lambda.Runtime.NODEJS_20_X,
+			runtime: Lambda.Runtime.NODEJS_22_X,
 			timeout: Duration.seconds(1),
 			memorySize: 1792,
 			code: Lambda.Code.fromAsset(lambdaSources.apiHealthCheck.zipFile),


### PR DESCRIPTION
See https://aws.amazon.com/de/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/
